### PR TITLE
Add Laravel 13 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.1",
-        "illuminate/support": "^10.0|^11.0|^12.0"
+        "illuminate/support": "^10.0|^11.0|^12.0|^13.0"
     },
     "require-dev": {
         "laravel/nova": "^5.0",


### PR DESCRIPTION
Adds `^13.0` to illuminate/* package constraints to support Laravel 13.