### PR TITLE
CI: bump actions/checkout to v5

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2


### PR DESCRIPTION
Silences the GitHub Actions deprecation warning — `actions/checkout@v4` runs on Node.js 20 (being removed Sept 2026). v5 runs on Node.js 24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)