### PR TITLE
docs: restructure README to Marshmallow format

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,15 @@
-[![Version](https://img.shields.io/packagist/v/marshmallow/nova-totals-footer)](https://github.com/marshmallow-packages/nova-totals-footer)
-[![Issues](https://img.shields.io/github/issues/marshmallow-packages/nova-totals-footer)](https://github.com/marshmallow-packages/nova-totals-footer)
-[![Licence](https://img.shields.io/github/license/marshmallow-packages/nova-totals-footer)](https://github.com/marshmallow-packages/nova-totals-footer)
+![alt text](https://marshmallow.dev/cdn/media/logo-red-237x46.png "marshmallow.")
 
-# Laravel Nova Totals footer
-This [Laravel Nova](https://nova.laravel.com) package is used for calculating the total of the columns that you wish to show.
+# Laravel Nova Totals Footer
+
+[![Latest Version on Packagist](https://img.shields.io/packagist/v/marshmallow/nova-totals-footer.svg?style=flat-square)](https://packagist.org/packages/marshmallow/nova-totals-footer)
+[![Tests](https://img.shields.io/github/actions/workflow/status/marshmallow-packages/nova-totals-footer/tests.yml?branch=develop&label=tests&style=flat-square)](https://github.com/marshmallow-packages/nova-totals-footer/actions/workflows/tests.yml)
+[![Total Downloads](https://img.shields.io/packagist/dt/marshmallow/nova-totals-footer.svg?style=flat-square)](https://packagist.org/packages/marshmallow/nova-totals-footer)
+
+This [Laravel Nova](https://nova.laravel.com) package adds a totals footer to your resource index tables, calculating the total of any columns you choose.
 
 ## Screenshot
+
 <img src="./resources/screenshot/totals-footer-screenshot.png">
 
 ## Requirements
@@ -15,29 +19,34 @@ This [Laravel Nova](https://nova.laravel.com) package is used for calculating th
 
 ## Installation
 
-Install via composer:
+Install the package via Composer:
 
-``` php
+```bash
 composer require marshmallow/nova-totals-footer
 ```
 
+The package is a Nova tool and is auto-discovered — no further registration is needed.
+
 ## Usage
-To include specific fields in the table footer, invoke their respective `calculate` methods. Within this method, specify the calculation logic to determine the desired value. By default, the available calculation methods include `sum`, `count`, `avg`, `min` and `max`. Refer to the example below for further clarification.
+
+To include a field in the table footer, call its `calculate()` method and describe the calculation. The available methods are `sum`, `count`, `avg`, `min` and `max`:
 
 ```php
+use Laravel\Nova\Fields\Currency;
+
 Currency::make('Revenue', 'revenue')
     ->required()
 
     /** 👇 This is where the magic happens */
     ->calculate(
-        method: 'sum', // sum, count, avg, min and max
+        method: 'sum',     // sum, count, avg, min, max
         title: 'Total',
         prefix: '$',
         postfix: '.00',
-        hideTitle: true, // true, false (default)
-        align: 'right', // left, right (default), center
+        hideTitle: true,   // true, false (default)
+        align: 'right',    // left, right (default), center
         titleAlign: 'right', // left, right (default), center
-        decimals: 2, // number of decimals to format the total with (default: 0)
+        decimals: 2,       // number of decimals to format the total with (default: 0)
     ),
 ```
 
@@ -45,8 +54,9 @@ Currency::make('Revenue', 'revenue')
 > another resource), the footer totals are calculated over the **related**
 > records only, matching the rows in the table.
 
-### Hide the header off footer
-This sound weird, but sometimes we needed to hide the header of the footer. We didn't need this extra footer row. Is you need to hide this, you can call the method below.
+### Hide the footer header
+
+Sometimes you don't want the extra title row above the totals. You can hide it:
 
 ```php
 use Marshmallow\NovaTotalsFooter\NovaTotalsFooter;
@@ -56,9 +66,7 @@ NovaTotalsFooter::hideHeader();
 
 ### Static analysis (PHPStan / Larastan)
 
-`calculate()` is a runtime macro on Nova's `Field`, so static analysers don't
-know about it by default. Register the shipped stub in your `phpstan.neon` to
-make it recognised (no more `@phpstan-ignore` on every call):
+`calculate()` is a runtime macro on Nova's `Field`, so static analysers don't know about it by default. Register the shipped stub in your `phpstan.neon` so it's recognised (no more `@phpstan-ignore` on every call):
 
 ```neon
 parameters:
@@ -78,24 +86,28 @@ composer test
 
 CI (`.github/workflows/tests.yml`) runs the suite against PHP 8.2–8.4 and expects `NOVA_USERNAME` and `NOVA_LICENSE_KEY` repository secrets.
 
-## Licence
+## Contributing
 
-The MIT License (MIT). Please see [License File](LICENCE) for more information.
+Feel free to suggest changes, ask for new features or fix bugs yourself. We're sure there are still a lot of improvements that could be made, and we would be very happy to merge useful pull requests.
+
+## Security Vulnerabilities
+
+Please report security vulnerabilities by email to [hello@marshmallow.nl](mailto:hello@marshmallow.nl) rather than via the public issue tracker.
+
+## Credits
+
+- [All Contributors](https://github.com/marshmallow-packages/nova-totals-footer/contributors)
+
+## License
+
+The MIT License (MIT). Please see the [License File](LICENCE) for more information.
 
 ## 💖 Sponsorships
 
 If you are reliant on this package in your production applications, consider [sponsoring us](https://github.com/sponsors/marshmallow-packages)! It is the best way to help us keep doing what we love to do: making great open source software.
 
-## Contributing
-
-Feel free to suggest changes, ask for new features or fix bugs yourself. We're sure there are still a lot of improvements that could be made, and we would be very happy to merge useful pull requests.
-
-### Special thanks to
--   [All Contributors](../../contributors)
-
 ## Made with ❤️ for open source
 
-At [Marshmallow](https://marshmallow.nl) we use a lot of open source software as part of our daily work.
-So when we have an opportunity to give something back, we're super excited!
+At [Marshmallow](https://marshmallow.nl) we use a lot of open source software as part of our daily work. So when we have an opportunity to give something back, we're super excited!
 
 We hope you will enjoy this small contribution from us and would love to [hear from you](mailto:hello@marshmallow.nl) if you find it useful in your projects. Follow us on [Twitter](https://x.com/marshmallow_dev) for more updates!


### PR DESCRIPTION
Restructure the README to the standard Marshmallow layout (logo, Packagist + tests + downloads badges, ordered sections) while preserving the screenshot, usage examples, and sponsorship section. Documents the `decimals` option, relation-scoped totals, the PHPStan stub, and the test suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)